### PR TITLE
Extend connectors

### DIFF
--- a/visual_code_builder/node.py
+++ b/visual_code_builder/node.py
@@ -53,6 +53,7 @@ class Node:
                 new_socket = NodeSocket(parent_node=self,
                                         position_index=output_idx,
                                         position=SocketPosition.RIGHT_TOP)
+                output_idx += 1
                 self.outputs.append(new_socket)
 
     @property

--- a/visual_code_builder/node.py
+++ b/visual_code_builder/node.py
@@ -63,7 +63,7 @@ class Node:
     def set_position(self, x_position: int, y_position: int):
         self.node_graphics.setPos(x_position, y_position)
 
-    def calculate_socket_position(self, index : int, position : SocketPosition):
+    def calculate_socket_position(self, index: int, position: SocketPosition):
         """
         Calculate and return the X,Y position for a socket.
         """

--- a/visual_code_builder/node.py
+++ b/visual_code_builder/node.py
@@ -40,7 +40,7 @@ class Node:
 
         if inputs is not None:
             input_idx = 0
-            for socket in inputs:
+            for _socket in inputs:
                 new_socket = NodeSocket(parent_node=self,
                                         position_index=input_idx,
                                         position=SocketPosition.LEFT_BOTTOM)
@@ -49,7 +49,7 @@ class Node:
 
         if outputs is not None:
             output_idx = 0
-            for socket in outputs:
+            for _socket in outputs:
                 new_socket = NodeSocket(parent_node=self,
                                         position_index=output_idx,
                                         position=SocketPosition.RIGHT_TOP)
@@ -86,4 +86,4 @@ class Node:
                      self.node_graphics.edge_roundness + index *
                      self._socket_spacing)
 
-        return x_pos, y_pos
+        return [x_pos, y_pos]

--- a/visual_code_builder/node.py
+++ b/visual_code_builder/node.py
@@ -43,7 +43,7 @@ class Node:
             for socket in inputs:
                 new_socket = NodeSocket(parent_node=self,
                                         position_index=input_idx,
-                                        position=SocketPosition.LEFT_TOP)
+                                        position=SocketPosition.LEFT_BOTTOM)
                 input_idx += 1
                 self.inputs.append(new_socket)
 
@@ -73,12 +73,14 @@ class Node:
             self.node_graphics.width
 
         if position in (SocketPosition.LEFT_BOTTOM, SocketPosition.RIGHT_BOTTOM):
+            # Start from bottom
             y_pos = (self.node_graphics.height -
                      self.node_graphics.edge_roundness -
                      self.node_graphics.text_padding -
                      index * self._socket_spacing)
 
         else:
+            # Start from top
             y_pos = (self.node_graphics.title_height +
                      self.node_graphics.text_padding +
                      self.node_graphics.edge_roundness + index *

--- a/visual_code_builder/node_connector.py
+++ b/visual_code_builder/node_connector.py
@@ -41,11 +41,18 @@ class NodeConnector:
         self.scene.graphics_scene.addItem(self.graphics)
 
     def update_positions(self):
-        self.graphics.set_source(*self.start_socket.get_socket_position())
+        source_position = self.start_socket.get_socket_position()
+        source_position[0] += self.start_socket.parent_node.node_graphics.pos().x()
+        source_position[1] += self.start_socket.parent_node.node_graphics.pos().y()
+
+        self.graphics.set_source(*source_position)
 
         if self.end_socket is not None:
-            self.graphics.set_destination(
-                *self.end_socket.get_socket_position())
+            end_position = self.end_socket.get_socket_position()
+            end_position[0] += self.end_socket.parent_node.node_graphics.pos().x()
+            end_position[1] += self.end_socket.parent_node.node_graphics.pos().y()
+
+            self.graphics.set_destination(*end_position)
 
         self.graphics.update()
 

--- a/visual_code_builder/node_connector.py
+++ b/visual_code_builder/node_connector.py
@@ -27,12 +27,13 @@ class NodeConnector:
                  scene,
                  start_socket,
                  end_socket,
-                 type: NodeConnectorType = NodeConnectorType.DIRECT):
+                 connector_type: NodeConnectorType = NodeConnectorType.DIRECT):
         self.scene = scene
         self.start_socket = start_socket
         self.end_socket = end_socket
 
-        self.connector_graphics = NodeConnectorGraphicsDirect(self) \
-            if type == NodeConnectorType.DIRECT else NodeConnectorGraphicsBezier(self)
+        self.graphics = NodeConnectorGraphicsDirect(self) \
+            if connector_type == NodeConnectorType.DIRECT \
+            else NodeConnectorGraphicsBezier(self)
 
-        self.scene.graphics_scene.addItem(self.connector_graphics)
+        self.scene.graphics_scene.addItem(self.graphics)

--- a/visual_code_builder/node_connector.py
+++ b/visual_code_builder/node_connector.py
@@ -36,4 +36,31 @@ class NodeConnector:
             if connector_type == NodeConnectorType.DIRECT \
             else NodeConnectorGraphicsBezier(self)
 
+        self.update_positions()
+
         self.scene.graphics_scene.addItem(self.graphics)
+
+    def update_positions(self):
+        self.graphics.set_source(*self.start_socket.get_socket_position())
+
+        if self.end_socket is not None:
+            self.graphics.set_destination(
+                *self.end_socket.get_socket_position())
+
+        self.graphics.update()
+
+    def remove_from_sockets(self):
+        if self.start_socket.connector is not None:
+            self.start_socket.connector = None
+
+        if self.end_socket.connector is not None:
+            self.end_socket.connector = None
+
+        self.end_socket = None
+        self.start_socket = None
+
+    def remove(self):
+        self.remove_from_sockets()
+        self.scene.graphics_scene.removeItem(self.graphics)
+        self.graphics = None
+        self.scene.remove_connection(self)

--- a/visual_code_builder/node_connector_graphics.py
+++ b/visual_code_builder/node_connector_graphics.py
@@ -45,6 +45,12 @@ class NodeConnectorGraphics(QtWidgets.QGraphicsPathItem):
         # X, Y
         self._position_destination = [200, 100]
 
+    def set_source(self, source_x: int, source_y: int):
+        self._position_source = [source_x, source_y]
+
+    def set_destination(self, destination_x: int, destination_y: int):
+        self._position_destination = [destination_x, destination_y]
+
     def paint(self, painter, option, widget=None):
         self.update_path()
 

--- a/visual_code_builder/node_connector_graphics_bezier.py
+++ b/visual_code_builder/node_connector_graphics_bezier.py
@@ -32,7 +32,7 @@ class NodeConnectorGraphicsBezier(NodeConnectorGraphics):
 
         # If destination is on the left-hand side, we need to make the
         # distance a minus.
-        if source[1] > destination[1]:
+        if source[0] > destination[0]:
             print("Swapping")
             distance *= -1
 
@@ -40,6 +40,6 @@ class NodeConnectorGraphicsBezier(NodeConnectorGraphics):
                      source[1],
                      destination[0] - distance,
                      destination[1],
-                     destination[0],
-                     destination[1])
+                     self._position_destination[0],
+                     self._position_destination[1])
         self.setPath(path)

--- a/visual_code_builder/node_connector_graphics_bezier.py
+++ b/visual_code_builder/node_connector_graphics_bezier.py
@@ -33,7 +33,6 @@ class NodeConnectorGraphicsBezier(NodeConnectorGraphics):
         # If destination is on the left-hand side, we need to make the
         # distance a minus.
         if source[0] > destination[0]:
-            print("Swapping")
             distance *= -1
 
         path.cubicTo(source[0] + distance,

--- a/visual_code_builder/node_editor_window.py
+++ b/visual_code_builder/node_editor_window.py
@@ -84,17 +84,17 @@ class NodeEditorWindow(QtWidgets.QWidget):
     def add_nodes(self):
         node_1 = Node(self.scene,
                       "Node #1",
-                      inputs=[1, 1, 1],
+                      inputs=[1, 2, 3],
                       outputs=[1])
         node_1.set_position(-350, -250)
         node_2 = Node(self.scene,
                       "Node #2",
-                      inputs=[1, 1, 1],
+                      inputs=[1, 2, 3],
                       outputs=[1])
         node_2.set_position(-75, 0)
         node_3 = Node(self.scene,
                       "Node #3",
-                      inputs=[1, 1, 1],
+                      inputs=[1, 2, 3],
                       outputs=[1])
         node_3.set_position(200, -150)
 
@@ -104,7 +104,7 @@ class NodeEditorWindow(QtWidgets.QWidget):
         conn_2 = NodeConnector(self.scene,
                                node_2.outputs[0],
                                node_3.inputs[0],
-                               type=NodeConnectorType.BEZIER)
+                               connector_type=NodeConnectorType.BEZIER)
 
     def _load_style_sheet(self, stylesheet_file: str):
         print(f"Loading node stylesheet '{stylesheet_file}")

--- a/visual_code_builder/node_editor_window.py
+++ b/visual_code_builder/node_editor_window.py
@@ -103,7 +103,7 @@ class NodeEditorWindow(QtWidgets.QWidget):
                                node_2.inputs[0])
         conn_2 = NodeConnector(self.scene,
                                node_2.outputs[0],
-                               node_3.inputs[0],
+                               node_3.inputs[2],
                                connector_type=NodeConnectorType.BEZIER)
 
     def _load_style_sheet(self, stylesheet_file: str):

--- a/visual_code_builder/node_graphics.py
+++ b/visual_code_builder/node_graphics.py
@@ -93,8 +93,8 @@ class NodeGraphics(QtWidgets.QGraphicsItem):
         return QtCore.QRectF(
             0,
             0,
-            2 * self.edge_roundness + self.width,
-            2 * self.edge_roundness + self.height
+            self.width,
+            self.height
         ).normalized()
 
     def paint(self, painter, _unused1, _unused2):

--- a/visual_code_builder/node_socket.py
+++ b/visual_code_builder/node_socket.py
@@ -36,10 +36,19 @@ class NodeSocket:
                  position: SocketPosition = SocketPosition.LEFT_TOP):
         self._parent_node = parent_node
         self._position_index = position_index
-        self._position = SocketPosition.LEFT_TOP
+        self._position = position
 
         self.socket_graphics = NodeSocketGraphics(self._parent_node.node_graphics)
 
         socket_pos = self._parent_node.calculate_socket_position(position_index,
                                                                  position)
         self.socket_graphics.setPos(*socket_pos)
+
+        self._connector = None
+
+    def get_socket_position(self):
+        return self._parent_node.calculate_socket_position(
+            self._position_index, self._position)
+
+    def set_connector(self, connector=None):
+        self._connector = connector

--- a/visual_code_builder/node_socket.py
+++ b/visual_code_builder/node_socket.py
@@ -46,6 +46,10 @@ class NodeSocket:
 
         self._connector = None
 
+    @property
+    def parent_node(self):
+        return self._parent_node
+
     def get_socket_position(self):
         return self._parent_node.calculate_socket_position(
             self._position_index, self._position)


### PR DESCRIPTION
Changes:
* Fixed bug in NodeGraphics paint() function
* Fixed bug for socket creation where the end socket index wasn't being incremented
* Renamed 'type' parameter to 'connector_type' to fix warning
* Bezier connector was using the y-axis for left-handedness instead of the x-axis
* The Connector is now positioned in the correct place related to the node - it currently won't move if the node moves yet